### PR TITLE
Prefix websocket request with /websocket

### DIFF
--- a/assets/digest/core.js
+++ b/assets/digest/core.js
@@ -38,7 +38,7 @@ define('websync', ['crypto'], function(crypto) {
         protocol = 'wss';
         path = WebSyncAuth.websocketUrl;
       }
-      WebSync.connection = new WebSocket(protocol + '://' + path + window.location.pathname);
+      WebSync.connection = new WebSocket(protocol + '://' + path + '/websocket' + window.location.pathname);
       _.each(WebSync.webSocketCallbacks, function(f, n) {
         WebSync.connection[n] = f;
       });

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -49,6 +49,8 @@ function wsConnection(ws) {
   var base = url.split('?')[0];
   var parts = base.split('/');
   console.log(parts);
+  // strip off websockets/ from the path
+  parts.shift();
   ws.docId = Base62.decode(parts[1]);
   if (parts[2] !== 'edit' && parts[2] !== 'view') {
     return;


### PR DESCRIPTION
This allows to run both the fronend and the backend
behind a single proxy server like nginx on a single port.
Example nginx.conf snippet:

location /websocket {
  proxy_pass http://127.0.0.1:4658;
}

location / {
  proxy_pass http://127.0.0.1:9292;
}